### PR TITLE
Add caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,11 @@ jobs:
       - run:
           name: 'Install Git'
           command: |
-            ssh ec2-user@ec2-3-134-85-99.us-east-2.compute.amazonaws.com "sudo yum install git"
+            ssh ec2-user@ec2-3-134-85-99.us-east-2.compute.amazonaws.com "sudo yum install git -y"
       - run:
           name: 'Install Docker Engine'
           command: |
-            ssh ec2-user@ec2-3-134-85-99.us-east-2.compute.amazonaws.com "sudo amazon-linux-extras install docker"
+            ssh ec2-user@ec2-3-134-85-99.us-east-2.compute.amazonaws.com "sudo amazon-linux-extras install docker -y"
       - run:
           name: 'Start Docker'
           command: |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Ideally, code changes, including the addition of new metrics, will be in separat
 
 #### Pre-production dashboards
 
-Pre-production dashboards can be edited and reviewed directly before they are published. Once the team has determined the dashboard is ready to go live the dashboard itself can be set to published and it can be given a "slug" (name in the URL).
+Pre-production dashboards can be edited and reviewed directly before they are published. Once the team has determined the dashboard is ready to go live the dashboard itself can be set to published and it can be given a "slug" (name in the URL). All draft dashboards should have "DRAFT" in the title.
   
 #### Production dashboards
 
@@ -105,6 +105,11 @@ Live production dashboards can be edited safely with the following process:
 1. Legacy dashboard can be deleted once the new one is up. 
 1. A new copy can then be made for future changes when needed.
 
+
+### Superset Security
+
+Superset ships with multiple security [roles](https://apache-superset.readthedocs.io/en/0.28.1/security.html). An additional role exists for OEC
+that disables an overall dashboard list view. All roles can be configured in Settings -> List Users, and Settings -> List Roles.
 
 ### Editing and creating tables, metrics and columns
 

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -7,8 +7,8 @@ ENABLE_JAVASCRIPT_CONTROLS = True
 
 # Default cache for Superset objects
 CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
-                "CACHE_DIR": "/home/ec2-user/docker/cache"}
+                "CACHE_DIR": "/cache"}
 
 # Cache for datasource metadata and query results
 DATA_CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
-                     "CACHE_DIR": "/home/ec2-user/docker/cache"}
+                     "CACHE_DIR": "/cache"}

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -1,4 +1,5 @@
 import os
+from celery.schedules import crontab
 APP_ICON = '/static/assets/images/mounted_images/logo.png'
 APP_ICON_WIDTH = 35
 SQLALCHEMY_DATABASE_URI = f'postgresql+psycopg2://superset_admin:{os.environ["POSTGRES_PASSWORD"]}@superset_db/superset'
@@ -12,3 +13,28 @@ CACHE_CONFIG = {"CACHE_TYPE": "filesystem",
 # Cache for datasource metadata and query results
 DATA_CACHE_CONFIG = {"CACHE_TYPE": "filesystem",
                      "CACHE_DIR": "/cache"}
+
+CELERYBEAT_SCHEDULE = {
+        "email_reports.schedule_hourly": {
+            "task": "email_reports.schedule_hourly",
+            "schedule": crontab(minute=1, hour="*"),
+        },
+        "reports.scheduler": {
+            "task": "reports.scheduler",
+            "schedule": crontab(minute="*", hour="*"),
+        },
+        "reports.prune_log": {
+            "task": "reports.prune_log",
+            "schedule": crontab(minute=0, hour=0),
+        },
+        # From https://superset.apache.org/docs/installation/cache
+        'cache-warmup-daily': {
+                'task': 'cache-warmup',
+                'schedule': crontab(minute=0, hour=6),  # Refresh daily, cache will last for 24 hours on site
+                'kwargs': {
+                    'strategy_name': 'top_n_dashboards',
+                    'top_n': 10,
+                    'since': '1 month ago',
+                    }
+        }
+    }

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -4,3 +4,6 @@ APP_ICON_WIDTH = 35
 SQLALCHEMY_DATABASE_URI = f'postgresql+psycopg2://superset_admin:{os.environ["POSTGRES_PASSWORD"]}@superset_db/superset'
 MAPBOX_API_KEY=f'{os.environ["MAPBOX_KEY"]}'
 ENABLE_JAVASCRIPT_CONTROLS = True
+
+CACHE_DIR='/home/ec2-user/docker'
+CACHE_TYPE='FileSystemCache'

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -6,9 +6,9 @@ MAPBOX_API_KEY=f'{os.environ["MAPBOX_KEY"]}'
 ENABLE_JAVASCRIPT_CONTROLS = True
 
 # Default cache for Superset objects
-CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
+CACHE_CONFIG = {"CACHE_TYPE": "filesystem",
                 "CACHE_DIR": "/cache"}
 
 # Cache for datasource metadata and query results
-DATA_CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
+DATA_CACHE_CONFIG = {"CACHE_TYPE": "filesystem",
                      "CACHE_DIR": "/cache"}

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -15,18 +15,6 @@ DATA_CACHE_CONFIG = {"CACHE_TYPE": "filesystem",
                      "CACHE_DIR": "/cache"}
 
 CELERYBEAT_SCHEDULE = {
-        "email_reports.schedule_hourly": {
-            "task": "email_reports.schedule_hourly",
-            "schedule": crontab(minute=1, hour="*"),
-        },
-        "reports.scheduler": {
-            "task": "reports.scheduler",
-            "schedule": crontab(minute="*", hour="*"),
-        },
-        "reports.prune_log": {
-            "task": "reports.prune_log",
-            "schedule": crontab(minute=0, hour=0),
-        },
         # From https://superset.apache.org/docs/installation/cache
         'cache-warmup-daily': {
                 'task': 'cache-warmup',

--- a/docker/config/superset_config.py
+++ b/docker/config/superset_config.py
@@ -5,5 +5,10 @@ SQLALCHEMY_DATABASE_URI = f'postgresql+psycopg2://superset_admin:{os.environ["PO
 MAPBOX_API_KEY=f'{os.environ["MAPBOX_KEY"]}'
 ENABLE_JAVASCRIPT_CONTROLS = True
 
-CACHE_DIR='/home/ec2-user/docker'
-CACHE_TYPE='FileSystemCache'
+# Default cache for Superset objects
+CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
+                "CACHE_DIR": "/home/ec2-user/docker/cache"}
+
+# Cache for datasource metadata and query results
+DATA_CACHE_CONFIG = {"CACHE_TYPE": "FileSystemCache",
+                     "CACHE_DIR": "/home/ec2-user/docker/cache"}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,5 +20,6 @@ services:
     volumes:
       - ./config:/app/pythonpath
       - ./images:/app/superset/static/assets/images/mounted_images/
+      - ./cache:/cache
     ports:
       - "8088:8080"


### PR DESCRIPTION
## Background
Adds a file system caching to Superset to speed up reloading of dashboards. Also includes a README update for Superset security settings.

## Validation Plan
I pushed this to the instance already since we don't have a staging instance so check that refreshing is faster and that there is a "cached" message in the chart view for charts you have already seen.
