### PR TITLE
remove temporal tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ When the database is initially built it needs to be set up with the following st
     - Number of children under 6 who are under 3.44X of the poverty line which is roughly 75% of the state median income.
     - Number of children under 6 in families who are under 200% of poverty with at least one working parent.
 - Shapefiles
-  - Census TIGER files with shapes associated with towns
+  - Census TIGER files with shapes associated with towns, blocks and legislative districts
   - Islands are ignored
 - ECE Reporter
   - Reports pulled from ECE reporter on a monthly basis
@@ -64,10 +64,7 @@ When the database is initially built it needs to be set up with the following st
   is provided in `ece_data/config_template.ini`.
   - _ECE Assumptions_    
     - Family income determination should be the most recent entry by determination date for the family that is not deleted
-    - For foster children, income should be set to 0 and family size should be 1.
-    - The queries are made on temporal tables that return data as if the query was run against the database at the end of the given reporting period. Changes since that time will not be reflected in the results.
-      - For backfilling data this approach does not work because data wasn't in the DB for some of these periods. March 8th 
-      will be the date that is used in this case since it was the first deadline for data submission.  
+    - For foster children, income should be set to 0 and family size should be 1.  
   - C4K data is not included 
   - Capacity data is pulled directly from the funding space table and only includes CDC and SS data. School Readiness data
   is unreliable and Head Start doesn't have defined spaces.
@@ -126,7 +123,7 @@ that disables an overall dashboard list view. All roles can be configured in Set
 - Superset has an option for metrics for Certification and Certification Details that the writer can use.
 
 #### Data Cleaning TODOS
-- Fill outstanding lat, longs for sites
+- Fill outstanding lat, longs for sites in July 2020.
 - Clean up town names
 - Resolve outstanding student records that aren't matching to any sites
 

--- a/src/data_integration/ece_data/child_pull.sql
+++ b/src/data_integration/ece_data/child_pull.sql
@@ -60,30 +60,22 @@ select
          ELSE family_det_temp.income
          END as family_income,
     family_det_temp.incomeNotDisclosed as family_income_not_disclosed
-    from dbo.funding
-        FOR SYSTEM_TIME AS OF :active_data_date
-        as f
+    from dbo.funding as f
     inner join dbo.funding_space
-        FOR SYSTEM_TIME AS OF :active_data_date
         as fs on f.fundingSpaceId = fs.id
     inner join dbo.reporting_period as rp_first on f.firstReportingPeriodId = rp_first.id and fs.source = rp_first.type
     inner join dbo.reporting_period as rp on fs.source = rp.type and rp.period = :period
     left outer join dbo.reporting_period as rp_last on f.lastReportingPeriodId = rp_last.ID and fs.source = rp_last.type
     inner join dbo.enrollment
-        FOR SYSTEM_TIME AS OF :active_data_date
         as enrollment on enrollment.Id = f.enrollmentId and
                                                             (enrollment.[exit] is null or enrollment.[exit] > rp.periodStart)
     inner join dbo.site
-        FOR SYSTEM_TIME AS OF :active_data_date
         as site on site.Id = enrollment.siteId
     inner join dbo.organization
-        FOR SYSTEM_TIME AS OF :active_data_date
         as organization on site.organizationId = organization.Id
     inner join dbo.child
-        FOR SYSTEM_TIME AS OF :active_data_date
         as child ON child.Id = enrollment.childId
     inner join dbo.family
-        FOR SYSTEM_TIME AS OF :active_data_date
         AS family on child.familyId = family.id
     left join (
         select
@@ -99,7 +91,6 @@ select
           ) as rn
 
         from dbo.income_determination
-         FOR SYSTEM_TIME AS OF :active_data_date
          where deletedDate is null) as family_det_temp
       on family_det_temp.familyId = family.Id and rn = 1
 where rp_first.period <= :period and (rp_last.period is null or rp_last.period >= :period)

--- a/src/data_integration/ece_data/pull_ece_data.py
+++ b/src/data_integration/ece_data/pull_ece_data.py
@@ -24,33 +24,20 @@ def get_space_df(db_conn: sqlalchemy.engine) -> pd.DataFrame:
     return df
 
 
-def get_beginning_and_end_of_month(date: datetime.date) -> (datetime.date, datetime.date):
-    """
-    Get first and last day of a month
-    :param date: date in a month to get the first and last date of
-    :return: tuple of first and last day of a month
-    """
-    start = date.replace(day=1)
-    end = date.replace(day=calendar.monthrange(date.year, date.month)[1])
-    return start, end
-
-
-def backfill_ece(db_conn: sqlalchemy.engine, start_month: str = START_DATE,
-                 end_month: str = END_DATE, data_active_date: str = BACKFILL_DATA_ACTIVE_DATA) -> pd.DataFrame:
+def backfill_ece(db_conn: sqlalchemy.engine, start_month: str = START_DATE, end_month: str = END_DATE) -> pd.DataFrame:
     """
     Pulls data from ECE Reporter for all the months between start and end month (inclusive) using data
     as of the data_active_date to adjust for data that was added in bulk after the relevant month
     :param db_conn: connection to ECE database
     :param start_month: First month to pull data from
     :param end_month: Last month to pull data from
-    :param data_active_date: Date that will serve as the version point of the database pull. Data will be pulled from
     the database as if the query were run on this day.
     :return: Combined dataframe of all the months worth of data in the range
     """
     report_list = []
     for month in pd.date_range(start_month, end_month, freq='MS').tolist():
         print(f"Pulling {month}")
-        parameters = {'period': month, 'active_data_date': data_active_date}
+        parameters = {'period': month}
         month_child_df = pd.read_sql(sql=text(open(CHILD_SQL_FILE).read()), params=parameters, con=db_conn)
         report_list.append(month_child_df)
     final_df = pd.concat(report_list)


### PR DESCRIPTION
## Background
Removes references to temporal tables from data pull from ECE database. This changes the reporting to reflect data as it currently stands in the database as opposed to when it was first entered. This may need to be reverted for funding reports but for now this is a more accurate way to collect data.